### PR TITLE
docs: add full project review and fix plan (doc/review-26-07-04.md)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,400 @@
+# Project Review & Fix Plan — cui-test-juli-logger
+
+- **Date:** 2026-07-04
+- **Reviewed version:** `2.2-SNAPSHOT` (branch `main` @ `96e3485`)
+- **Scope:** Full review of `src/main`, `src/test`, build/CI config, and documentation.
+- **Nature of this document:** Review + fix *plan* only. No production/test code is changed by
+  the commit that introduces this file. Each finding carries a concrete fix hint; the actual
+  fixes are to be executed later in the PR clusters proposed in
+  [Section 4 — PR Partitioning](#4-pr-partitioning).
+
+---
+
+## 1. Executive Summary
+
+The library is small (≈2k LOC), well-structured, and its 38 tests pass green
+(`./mvnw clean test` → `BUILD SUCCESS`). The public API is clean and the JUnit-5 integration is
+solid, including the recently added `@Nested` inheritance support.
+
+However the review surfaced one **real correctness bug** (NPE that contradicts a documented
+contract), a **thread-safety inconsistency**, and — most significantly — a **configuration
+subsystem whose documented "properties file" behaviour is not implemented at all** and whose
+"programmatic" tier is dead, unreachable code. There is also a cluster of documentation
+drift, misleading assertion messages, and test-isolation weaknesses.
+
+None of the findings block current usage, but several are latent traps for users
+(the null-logger NPE, the non-existent `cui_logger.properties` support) and should be resolved.
+
+### Severity overview
+
+| Severity | Count | IDs |
+|----------|-------|-----|
+| High     | 1     | BUG-1 |
+| Medium   | 6     | BUG-3, CFG-1, CFG-2, CFG-3, TEST-1, MSG-1 |
+| Low      | 11    | BUG-2, CFG-4, DOC-1..4, MSG-2, TEST-2, TEST-3, NIT-1, NIT-2 |
+
+---
+
+## 2. Findings
+
+### 2.1 Correctness / Bugs
+
+#### BUG-1 — `TestLoggerFactory.addLogger(TestLogLevel, String)` throws NPE on `null` logger name  *(High)*
+
+`src/main/java/de/cuioss/test/juli/TestLoggerFactory.java:125-131`
+
+```java
+public static void addLogger(TestLogLevel logLevel, String loggerName) {
+    CONSOLE_HANDLER.adjustLevel(logLevel);
+    if (isEmpty(loggerName)) {
+        Logger.getLogger("").setLevel(logLevel.getJuliLevel());
+    }
+    Logger.getLogger(loggerName).setLevel(logLevel.getJuliLevel());   // <-- reached even when loggerName == null
+}
+```
+
+The `if` block is missing a `return`. When `loggerName == null`, `isEmpty` is `true`, the root
+logger is set, and then `Logger.getLogger(null)` is invoked, which throws
+`NullPointerException`. This directly contradicts the documented contract of the public entry
+points that funnel into this method:
+
+- `TestLogLevel.addLogger(String)` javadoc: *"if it is `null` or empty it will set the
+  root-logger"* (`TestLogLevel.java:94-97`)
+- `TestLoggerFactory.addLogger` javadoc: *"if it is `null` or empty it will set the root-logger"*
+
+So `TestLogLevel.DEBUG.addLogger((String) null)` is documented to configure the root logger but
+actually blows up.
+
+**Fix hint:** short-circuit the empty/null case:
+
+```java
+public static void addLogger(TestLogLevel logLevel, String loggerName) {
+    CONSOLE_HANDLER.adjustLevel(logLevel);
+    if (isEmpty(loggerName)) {
+        Logger.getLogger("").setLevel(logLevel.getJuliLevel());
+        return;
+    }
+    Logger.getLogger(loggerName).setLevel(logLevel.getJuliLevel());
+}
+```
+
+Add a regression test (`TestLoggerFactoryTest` / `TestLogLevelTest`) asserting
+`TestLogLevel.DEBUG.addLogger((String) null)` sets the root level and does not throw.
+
+---
+
+#### BUG-2 — Root logger set twice for empty string  *(Low, same root cause as BUG-1)*
+
+Same code path: for a non-null empty string `""`, the root logger is set in the `if` block and
+then set again via `Logger.getLogger("")`. Harmless but redundant. The `return` from BUG-1 also
+resolves this.
+
+---
+
+#### BUG-3 — Inconsistent synchronization when iterating the records list  *(Medium)*
+
+`src/main/java/de/cuioss/test/juli/TestLogHandler.java`
+
+`records` is a `Collections.synchronizedList(...)`. The Java contract requires the caller to
+**manually synchronize on the list while iterating or streaming it**. Only one method honours
+this:
+
+- `resolveLogMessages(TestLogLevel)` (line 194-199) — correctly wraps the stream in
+  `synchronized (records) { ... }`.
+
+Every other traversal does **not**:
+
+- `resolveLogMessagesForLogger(String)` — `records.stream()...` (line 112)
+- `getRecordsAsString()` — `new ArrayList<>(records)` copy constructor iterates the list
+  (line 240)
+- indirectly, the many `resolveLogMessages*` overloads that stream intermediate results.
+
+Under concurrent `publish()` (e.g. code under test logging from multiple threads while an
+assertion reads records) this can throw `ConcurrentModificationException`.
+
+**Fix hint:** make synchronization consistent. Cleanest option: take a defensive snapshot
+under `synchronized (records)` at the start of each query and stream the snapshot, e.g. a
+private `List<LogRecord> snapshot()` helper; or switch the backing store to
+`CopyOnWriteArrayList` (simpler, safe iteration, acceptable given the small volumes in tests).
+Prefer the `CopyOnWriteArrayList` approach unless write throughput is a concern — it removes the
+whole class of iteration bugs.
+
+---
+
+### 2.2 Configuration subsystem — documented but not implemented
+
+#### CFG-1 — `cui_logger.properties` file loading is documented but never implemented  *(Medium)*
+
+The following all promise configuration via a `cui_logger.properties` file in
+`src/test/resources`:
+
+- `README.adoc` (implied via "Configure for all tests")
+- `CLAUDE.md` → *"Default configuration file `cui_logger.properties` in `src/test/resources`"*
+- `EnableTestLogger.java:44-49` javadoc → *"settings found either within
+  `System.getProperty(String)` and `cui_logger.properties`"*
+- `TestLoggerFactory.configureLogger()` javadoc → *"the file `cui_logger.properties` usually
+  located directly in `src/test/resources`"*
+
+**No code anywhere reads a properties file.** `StaticLoggerConfigurator` only consults
+`System.getProperties()` and an in-memory `defaultConfiguration` map (see CFG-2). There is no
+`cui_logger.properties` in the repo and no classpath-resource loading logic.
+
+**Fix hint — decide one of two directions (product decision, see
+[Section 5](#5-open-decision)):**
+
+- **Option A (implement):** load `cui_logger.properties` from the classpath in
+  `StaticLoggerConfigurator` (e.g. via `Thread.currentThread().getContextClassLoader()
+  .getResourceAsStream("cui_logger.properties")`), merge into the lowest-priority tier
+  (below System properties), and add tests + a sample resource.
+- **Option B (remove claim):** strip every mention of `cui_logger.properties` from the docs
+  and javadoc, and delete the now-dead default machinery (ties into CFG-2).
+
+Recommendation: **Option A** — the file-based tier is the natural way to configure logging for
+a whole test module and is clearly the original design intent; implementing it makes the docs
+true and closes CFG-2/CFG-3 in the same stroke.
+
+---
+
+#### CFG-2 — Dead "programmatic/default" configuration tier  *(Medium)*
+
+- `StaticLoggerConfigurator.defaultConfiguration` (`ConcurrentHashMap`) is **never populated** —
+  there is no setter and no caller.
+- `ConfigurationKeys.populateDefaults(Map)` and `ConfigurationKeys.CONFIGURATION_DEFAULT_ROOT_LOG_LEVEL`
+  are **never referenced** from production code (dead code).
+
+The javadoc of `getStringProperty`/`getBooleanProperty` advertises a three-tier precedence
+("Programmatically configured → System properties → Default Configuration"), but two of the
+three tiers can never contain anything.
+
+**Fix hint:** either wire the default tier up (call `populateDefaults` in the
+`StaticLoggerConfigurator` constructor and, if Option A of CFG-1 is chosen, feed file contents
+into the map) **or** delete `defaultConfiguration`, `populateDefaults`,
+`CONFIGURATION_DEFAULT_ROOT_LOG_LEVEL`, and correct the precedence javadoc. Keep this consistent
+with the CFG-1 decision.
+
+---
+
+#### CFG-3 — `getConfiguredLogger()` scans only System properties  *(Medium, coupled to CFG-1/2)*
+
+`StaticLoggerConfigurator.getConfiguredLogger()` (line 81-94) iterates
+`System.getProperties().keySet()` exclusively. Even once the default/file tier is populated,
+concrete per-logger entries (`cui.logger.<name>`) coming from that tier are ignored.
+
+**Fix hint:** iterate the union of System-property keys and the default/file-tier keys (or
+whatever tiers survive the CFG-1 decision), then resolve each via `getStringProperty` so the
+documented precedence is honoured.
+
+---
+
+#### CFG-4 — `getBooleanProperty` has no production caller  *(Low)*
+
+`StaticLoggerConfigurator.getBooleanProperty` is referenced only by
+`StaticLoggerConfiguratorTest`. It is either intended public API surface (then it should be
+documented/covered) or dead.
+
+**Fix hint:** if no configuration key is boolean-typed, remove it; otherwise keep and document
+its intended use. Low priority — bundle with the CFG cleanup.
+
+---
+
+### 2.3 Documentation
+
+#### DOC-1 — `@EnableTestLogger.trace()` javadoc maps TRACE to the wrong JUL level  *(Low)*
+
+`EnableTestLogger.java:77-80` states TRACE *"implicitly maps to `Level.FINEST`"*, but
+`TestLogLevel.TRACE` maps to `Level.FINER` (`TestLogLevel.java:42`). No level in the enum maps
+to `FINEST`.
+
+**Fix hint:** change the javadoc to `Level.FINER`.
+
+---
+
+#### DOC-2 — Typos in `about.adoc` / `README.adoc`  *(Low)*
+
+- `src/site/asciidoc/about.adoc`: *"The logger and level are **rested** for each test"* →
+  "reset".
+- `README.adoc:48`: *"resetted"* → "reset".
+
+**Fix hint:** correct both.
+
+---
+
+#### DOC-3 — Docs claim file-based configuration (see CFG-1)  *(Low)*
+
+`CLAUDE.md`, `README.adoc`, `about.adoc`, and multiple javadocs describe `cui_logger.properties`.
+Resolve together with CFG-1 so docs and code agree.
+
+---
+
+#### DOC-4 — Copyright header year is `© 2025`  *(Low)*
+
+All source headers read *"Copyright © 2025"* on a `2.2-SNAPSHOT` reviewed in 2026. This is
+normally driven by the parent POM's license plugin.
+
+**Fix hint:** confirm the `license-maven-plugin` (from `cui-java-parent`) year configuration;
+this is likely regenerated automatically and may need no manual edit. Verify only.
+
+---
+
+### 2.4 Assertion-message quality
+
+#### MSG-1 — `assertNoLogMessagePresent(TestLogLevel, String)` prints a misleading label  *(Medium)*
+
+`LogAsserts.java:73-80` performs a **contains** match (`resolveLogMessagesContaining`) but builds
+its failure message with the `MESSAGE_EXACTLY` label (`" and message is exactly="`). On failure
+the user is told the exact message was found when in fact a substring matched.
+
+**Fix hint:** use `MESSAGE_CONTAINS` in that assertion message.
+
+---
+
+#### MSG-2 — Inconsistent emptiness assertions  *(Low)*
+
+`LogAsserts` mixes `assertTrue(messages.isEmpty())`, `assertEquals(0, size)`, and
+`assertNotEquals(0, size)` for equivalent "none present" / "at least one present" checks
+(e.g. the two `assertNoLogMessagePresent` overloads use different idioms).
+
+**Fix hint:** standardize (`isEmpty()` for "none", `!isEmpty()` / explicit count for the rest)
+for readability. Cosmetic.
+
+---
+
+### 2.5 Tests
+
+#### TEST-1 — Test pollution: leaked `cui.logger.*` system property  *(Medium)*
+
+`StaticLoggerConfiguratorTest.shouldDetermineLoggerFromSystemProperty` (line 47-52) sets
+`System.setProperty("cui.logger.test.logger", ...)` but the `@BeforeEach` only clears
+`some.system.property`. The logger property therefore leaks for the rest of the JVM run and can
+influence any later test that invokes `TestLoggerFactory.configureLogger()`
+(which enumerates `cui.logger.*`).
+
+**Fix hint:** clear the property in an `@AfterEach` (or use a try/finally / a dedicated
+system-property extension). Also clear it in `@BeforeEach` for symmetry.
+
+---
+
+#### TEST-2 — `TestLoggerFactoryTest.shouldReadConfiguration` asserts nothing meaningful  *(Low)*
+
+`TestLoggerFactoryTest.java:57-71` sets levels, then calls `configureLogger()` with **no
+assertion afterward**. The name promises configuration verification but the test is a smoke test
+at best.
+
+**Fix hint:** set `cui.logging.root_log_level` (and a `cui.logger.<name>`) via system property,
+call `configureLogger()`, then assert the resulting root/logger levels; clean the properties up
+afterward (coordinate with TEST-1).
+
+---
+
+#### TEST-3 — Coverage gaps  *(Low)*
+
+No tests exist for:
+
+- BUG-1 (`addLogger` with `null` logger name).
+- `ConsoleHandlerModifier` (save/adjust/restore level behaviour) — currently untested directly.
+- `TestLogLevel.parse(null)` NPE contract (`requireNonNull`).
+- `configureLogger()` actually changing levels from configuration (see TEST-2).
+- Concurrent `publish()` vs. query iteration (ties to BUG-3).
+
+**Fix hint:** add targeted unit tests alongside the corresponding fixes so each PR lands with its
+own regression coverage.
+
+---
+
+### 2.6 Nits
+
+- **NIT-1 (Low):** Many files carry a double blank line after the import block (e.g.
+  `TestLogHandler.java:28-30`, `TestLoggerFactory.java:28-30`). Cosmetic; a formatter pass would
+  normalize. Only worth doing if the build's formatter/checkstyle is authoritative.
+- **NIT-2 (Low):** `TestLoggerFactory` holds static singletons (`configuration`,
+  `CONSOLE_HANDLER`) and mutates the global JUL root logger. This is inherent to JUL but means
+  **parallel test execution is unsupported**. Document this limitation explicitly in the
+  `@EnableTestLogger` / `TestLoggerFactory` javadoc rather than leaving it implicit.
+
+---
+
+## 3. What is good (no action needed)
+
+- Clean, well-documented public API with consistent naming.
+- `@Nested` inheritance in `TestLoggerController.collectAnnotationsFromHierarchy` is correct and
+  well tested (`EnableTestLoggerTest`).
+- Null-record handling in `TestLogHandler.publish` is defensive and tested.
+- `TestLogLevel.parse` / `getLevelOrDefault` fallbacks are sensible and covered.
+- CI wiring via the shared `cuioss-organization` reusable workflow is current (v0.6.8).
+
+---
+
+## 4. PR Partitioning
+
+Findings are grouped into four cohesive, independently-reviewable PRs. Ordering matters only in
+that **PR-2 depends on the CFG decision** ([Section 5](#5-open-decision)); the others are
+independent and can proceed in parallel.
+
+### PR-1 — Correctness & thread-safety
+**Cluster:** BUG-1, BUG-2, BUG-3
+**Risk:** Low-Medium · **Priority:** Highest (ship first)
+- Add the missing `return` in `TestLoggerFactory.addLogger` (fixes NPE + double-set).
+- Make `TestLogHandler` record iteration consistently thread-safe (snapshot or
+  `CopyOnWriteArrayList`).
+- Add regression tests: null logger name; concurrent publish/query.
+
+### PR-2 — Configuration subsystem alignment
+**Cluster:** CFG-1, CFG-2, CFG-3, CFG-4, DOC-3
+**Risk:** Medium · **Priority:** High · **Blocked on:** [Section 5](#5-open-decision)
+- Either implement `cui_logger.properties` loading (Option A) or remove the dead tier and docs
+  (Option B), consistently across code + docs + javadoc.
+- Reconcile `getConfiguredLogger` precedence.
+- Tests: file-based config (Option A) or precedence/removal assertions (Option B).
+
+### PR-3 — Documentation & assertion messages
+**Cluster:** DOC-1, DOC-2, DOC-4, MSG-1, MSG-2
+**Risk:** Very low · **Priority:** Medium (quick win)
+- Fix TRACE→FINER javadoc, "reset" typos, verify license year.
+- Correct the `MESSAGE_EXACTLY`→`MESSAGE_CONTAINS` label; standardize emptiness assertions.
+
+### PR-4 — Test hardening
+**Cluster:** TEST-1, TEST-2, TEST-3, NIT-2
+**Risk:** Low · **Priority:** Medium
+- Fix system-property leakage; give `shouldReadConfiguration` real assertions.
+- Add `ConsoleHandlerModifier` / `parse(null)` coverage.
+- Document the no-parallel-execution limitation (NIT-2).
+
+> **NIT-1** (formatting) is intentionally left unbundled — apply it only if/when a formatter or
+> checkstyle rule makes it authoritative, to avoid noisy unrelated diffs.
+
+### Suggested sequence
+
+```
+PR-1  ─┐
+PR-3  ─┼─► independent, mergeable in any order
+PR-4  ─┘
+PR-2  ───► after the CFG decision in Section 5 is made
+```
+
+---
+
+## 5. Open Decision (needs product owner input before PR-2)
+
+**How should test-wide logging configuration be supplied?**
+
+- **Option A — Implement `cui_logger.properties` loading** (recommended). Makes the existing
+  documentation truthful, revives the intended file-based tier, and closes CFG-1/2/3 together.
+  Cost: new resource-loading code + tests.
+- **Option B — Drop the file-based claim.** Remove all `cui_logger.properties` references and the
+  dead default machinery; keep System-properties-only configuration. Cost: lower, but removes a
+  documented capability users may expect.
+
+This is the only finding whose fix direction cannot be inferred purely from the code, because it
+turns on original design intent. Everything else in Sections 2/4 is unambiguous.
+
+---
+
+## 6. Verification checklist (per fix PR)
+
+- [ ] `./mvnw clean test` green (baseline: 38 tests passing).
+- [ ] New regression test accompanies each behavioural change.
+- [ ] Docs/javadoc updated in the same PR as the code they describe.
+- [ ] No unrelated formatting churn (keep diffs reviewable).
+- [ ] SonarCloud quality gate not regressed (coverage, no new code smells).
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

Adds a comprehensive project review and fix **plan** at `doc/review-26-07-04.md`. This PR is
planning-only — it introduces a single Markdown document and changes **no production or test code**.

The review was produced from a full read of `src/main`, `src/test`, build/CI config, and docs.
Baseline is green: `./mvnw clean test` → 38 tests passing.

## Key findings (see the doc for full detail + fix hints)

- **BUG-1 (High):** `TestLoggerFactory.addLogger(TestLogLevel, String)` throws `NullPointerException`
  on a `null` logger name (missing `return`), contradicting the documented "null → root logger" contract.
- **BUG-3 (Medium):** inconsistent synchronization while iterating the `synchronizedList` of records
  — only one query method synchronizes; others risk `ConcurrentModificationException`.
- **CFG-1..4 (Medium):** the documented `cui_logger.properties` file-based configuration is **not
  implemented**, and the "programmatic/default" configuration tier is dead, unreachable code.
- **DOC / MSG / TEST (Low–Medium):** TRACE→FINEST javadoc drift (actually FINER), a misleading
  assertion-message label, leaked system property causing test pollution, and coverage gaps.

## Proposed PR partitioning (future work)

1. **PR-1** — Correctness & thread-safety (BUG-1/2/3)
2. **PR-2** — Configuration subsystem alignment (CFG-1..4) — *blocked on one open decision*
3. **PR-3** — Documentation & assertion messages (DOC/MSG)
4. **PR-4** — Test hardening (TEST-1/2/3)

## Open decision

One finding (CFG-1) needs a product call: **implement** `cui_logger.properties` loading (recommended)
vs. **remove** the documented-but-unimplemented claim. Captured in Section 5 of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpS9WTytcPXpNs2rVop3uu)_